### PR TITLE
WAL-170-automatically-add-wallaby-runs-to-the-relevant-survey-components-based-on-name

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
           python-version: '3.10.10'
           architecture: 'x64'
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-build-${{ env.cache-name }}

--- a/README.md
+++ b/README.md
@@ -76,5 +76,15 @@ python manage.py createsuperuser --username <username>
 
 ### GAVO DACHS
 
+Edit the config file `vo/vo.rd` to configure the VO service
+
+```
+docker-compose up --build -d survey_vo
+```
+
 ### NGINX reverse proxy
+
+```
+docker-compose up --build -d survey_nginx
+```
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Edit the config file `vo/vo.rd` to configure the VO service
 docker-compose up --build -d survey_vo
 ```
 
+Sometimes I find that I need to give the `gavo` user ownership of the directory `/var/gavo`, otherwise there are warnings in the deployment. You can run
+
+```
+chown -R gavo:gavo /var/gavo/
+```
+
 ### NGINX reverse proxy
 
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ docker-compose up --build -d survey_web
 
 This is easiest done inside of the container. To create the superuser you will be prompted to provide a password.
 
-
 ```
 docker exec -it survey_web /bin/bash
 ```
@@ -76,21 +75,12 @@ python manage.py createsuperuser --username <username>
 
 ### GAVO DACHS
 
-Edit the config file `vo/vo.rd` to configure the VO service
-
-```
-docker-compose up --build -d survey_vo
-```
-
-Sometimes I find that I need to give the `gavo` user ownership of the directory `/var/gavo`, otherwise there are warnings in the deployment. You can run
-
-```
-chown -R gavo:gavo /var/gavo/
-```
-
 ### NGINX reverse proxy
 
-```
-docker-compose up --build -d survey_nginx
-```
+## Dependent services
 
+On changes to the deployment of these services you will also need to update the following configuration items:
+
+* `database.env` on Setonix (WALLABY pipeline)
+* `sofiax.ini` on Setonix (WALLABY pipeline)
+* `wallaby.ini` on AusSRC workflow service (triggers)

--- a/web/survey/admin.py
+++ b/web/survey/admin.py
@@ -920,6 +920,8 @@ class RunAdmin(ModelAdmin):
         except Exception as e:
             messages.error(request, str(e))
 
+    _auto_assign_to_component.short_description = 'Auto-assign Run to Survey Component'
+
     @task(exclusive_func_with=['internal_cross_match', 'external_cross_match', 'release_sources', 'delete_run', 'download_summaries'])
     def delete_run(self, request, queryset):
         names = [i.name for i in queryset]

--- a/web/survey/admin.py
+++ b/web/survey/admin.py
@@ -914,7 +914,7 @@ class RunAdmin(ModelAdmin):
                         messages.error(request, f"Unable to auto-assign run '{run.name}' to\
                             survey component '{component_name}'.\
                             Survey component '{component_name}' does not exist.")
-                    #No need to look for another match
+                    # No need to look for another match
                     break
             if match_found is False:
                 messages.error(request, f"Run '{run.name}' does not match any known\

--- a/web/survey/models.py
+++ b/web/survey/models.py
@@ -664,7 +664,6 @@ if settings.PROJECT == 'WALLABY':
             managed = False
             db_table = 'kinematic_model'
 
-
     class KinematicModel_3KIDNAS(models.Model):
         id = models.BigAutoField(primary_key=True)
         detection = models.ForeignKey(Detection, models.DO_NOTHING)
@@ -713,7 +712,6 @@ if settings.PROJECT == 'WALLABY':
             managed = False
             db_table = 'kinematic_model_3kidnas'
 
-
     class WKAPP_Product(models.Model):
         id = models.BigAutoField(primary_key=True)
         kinematic_model = models.ForeignKey(KinematicModel, db_column='kinematic_model_id', to_field='id', on_delete=models.CASCADE)
@@ -732,7 +730,6 @@ if settings.PROJECT == 'WALLABY':
         class Meta:
             managed = False
             db_table = 'wkapp_product'
-
 
     class WRKP_Product(models.Model):
         id = models.BigAutoField(primary_key=True)

--- a/web/survey/utils/components.py
+++ b/web/survey/utils/components.py
@@ -9,6 +9,9 @@ def get_survey_components():
         components_dict[sc.name] = [i.run.name for i in sc.surveycomponentrun_set.all()]
     return components_dict
 
+def get_survey_component_by_name(in_name):
+    """Return a SurveyComponent object by its name."""
+    return SurveyComponent.objects.filter(name=in_name).first()
 
 def get_release_name(name):
     """Return name of source depending on the project.

--- a/web/survey/utils/components.py
+++ b/web/survey/utils/components.py
@@ -13,6 +13,14 @@ def get_survey_component_by_name(in_name):
     """Return a SurveyComponent object by its name."""
     return SurveyComponent.objects.filter(name=in_name).first()
 
+def get_survey_component_runs():
+    """Return a list of all runs associated with survey components."""
+    survey_component_runs = []
+    survey_components = get_survey_components()
+    for runs in survey_components.values():
+        survey_component_runs += runs
+    return survey_component_runs
+
 def get_release_name(name):
     """Return name of source depending on the project.
 

--- a/web/survey/utils/components.py
+++ b/web/survey/utils/components.py
@@ -9,9 +9,11 @@ def get_survey_components():
         components_dict[sc.name] = [i.run.name for i in sc.surveycomponentrun_set.all()]
     return components_dict
 
+
 def get_survey_component_by_name(in_name):
     """Return a SurveyComponent object by its name."""
     return SurveyComponent.objects.filter(name=in_name).first()
+
 
 def get_survey_component_runs():
     """Return a list of all runs associated with survey components."""
@@ -20,6 +22,7 @@ def get_survey_component_runs():
     for runs in survey_components.values():
         survey_component_runs += runs
     return survey_component_runs
+
 
 def get_release_name(name):
     """Return name of source depending on the project.

--- a/web/survey/utils/constants.py
+++ b/web/survey/utils/constants.py
@@ -1,2 +1,2 @@
 """Constants for survey run naming patterns and matching survey components."""
-RUN_NAME_TO_SURVEY_COMPONENT = {r"^SB.*_gc$": "Quality-Check", r"^SER.*$": "WALLABY v1"}
+RUN_NAME_TO_SURVEY_COMPONENT = {r"^SB.*_qc$": "Quality-Check", r"^SER.*$": "WALLABY v1"}

--- a/web/survey/utils/constants.py
+++ b/web/survey/utils/constants.py
@@ -1,0 +1,2 @@
+"""Constants for survey run naming patterns and matching survey components."""
+RUN_NAME_TO_SURVEY_COMPONENT = {r"^SB.*_gc$": "Quality-Check", r"^SER.*$":"WALLABY v1"}

--- a/web/survey/utils/constants.py
+++ b/web/survey/utils/constants.py
@@ -1,2 +1,2 @@
 """Constants for survey run naming patterns and matching survey components."""
-RUN_NAME_TO_SURVEY_COMPONENT = {r"^SB.*_gc$": "Quality-Check", r"^SER.*$":"WALLABY v1"}
+RUN_NAME_TO_SURVEY_COMPONENT = {r"^SB.*_gc$": "Quality-Check", r"^SER.*$": "WALLABY v1"}


### PR DESCRIPTION
Added new menu in Runs:
<img width="530" alt="Screenshot 2025-07-02 at 12 35 43 pm" src="https://github.com/user-attachments/assets/7cfbd2ca-8c1d-4848-a426-04d9ee16e6f4" />

Results and errors after run:
<img width="1134" alt="Screenshot 2025-07-02 at 11 20 00 am" src="https://github.com/user-attachments/assets/11463ee7-ecbc-4ce3-91bf-b2fb0f8b642f" />


